### PR TITLE
Added a minimum height to the YA tab

### DIFF
--- a/app/views/clubs/index.html.erb
+++ b/app/views/clubs/index.html.erb
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<div class="container">
+<div class="container" style="min-height: 450px">
   <ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
     <li class="nav-item">
       <a class="nav-link active" id="pills-home-tab" data-toggle="pill" href="#pills-home" role="tab"


### PR DESCRIPTION
**What?**
Added a min height to the container containing the material showing under the tabs.

**Why?**
So that when you click on YA, the screen won't resize. Perhaps the height could be increased dynamically somehow. (Future issue) (Minor issue though)