### PR TITLE
Try number 2 at resolving the multiple cards in cat

### DIFF
--- a/app/views/clubs/index.html.erb
+++ b/app/views/clubs/index.html.erb
@@ -189,7 +189,7 @@
       <div class="row">
         <% @clubs.each do |club|%>
         <% club.categories.each do |category| %>
-        <% if category.name.downcase.include? "science fiction" %>
+        <% if category.name.downcase.include? "science" %>
         <div class="col-lg-4">
 
           <div class="card club-card rounded mb-3" style="max-width: 540px;">


### PR DESCRIPTION
**Why?**
Some of the categories were showing multiple cards.

**How?**
Previously I had the uniq on the string so that each genre term would only show up once. However, I may have forgotten to change the tab "science fiction" to fiction to check results. I believe the issue was actually with the fiction tab, so perhaps this will not be the final fix. But here's to hoping