### PR TITLE
fixed username/avatar to match each persons actual message

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,8 +17,10 @@
   display: flex;
   min-height: 100vh;
   flex-direction: column;
+  margin: 0;
 }
 
 .site-content {
   flex: 1;
 }
+

--- a/app/assets/stylesheets/pages/rooms/_chat.scss
+++ b/app/assets/stylesheets/pages/rooms/_chat.scss
@@ -20,3 +20,4 @@
   padding-left: 60px;
   max-width: 10%;
 }
+

--- a/app/channels/room_channel.rb
+++ b/app/channels/room_channel.rb
@@ -1,9 +1,11 @@
 class RoomChannel < ApplicationCable::Channel
   def subscribed
     room = Room.find(params[:id])
-    stream_for room
+    # stream_for room
+    stream_from "chat_#{params[:room]}"
+  end
 
-    # or
-    # stream_from "room_#{params[:room]}"
+  def receive(data)
+    ActionCable.server.broadcast("chat_#{params[:room]}", data)
   end
 end

--- a/app/controllers/room_messages_controller.rb
+++ b/app/controllers/room_messages_controller.rb
@@ -2,9 +2,12 @@ class RoomMessagesController < ApplicationController
   before_action :load_entities
 
   def create
+    @room = Room.find(params[:room_id])
     @room_message = RoomMessage.new user: current_user,
                                        room: @room,
                                        message: params.dig(:room_message, :message)
+    @room_message.room = @room
+    @room_message.user = current_user
     @club = @room.club
     authorize @room_message
     if @room_message.save

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,4 +1,5 @@
 <br>
+<div class="container-room">
 <h2 class="pb-2 pt-2 pl-2 text-center mt-5">
   <%= @room.name %>
 </h2>
@@ -19,8 +20,8 @@
         <div class="chat-message-container" id="messages" data-room-id="<%= @room.id  %>">
           <div class="row no-gutters">
             <div class="col-auto text-center">
-              <% if current_user.profile_photo.attached? %>
-                <%= cl_image_tag current_user.profile_photo.key, class: "avatar-chat" %>
+              <% if room_message.user.profile_photo.attached? %>
+                <%= cl_image_tag room_message.user.profile_photo.key, class: "avatar-chat" %>
               <% else %>
                 <%= image_tag "https://images.unsplash.com/photo-1452882628481-6a2da9481239?ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80", class: "avatar-chat" %>
               <% end %>
@@ -29,7 +30,7 @@
             <div class="col">
               <div class="message-content">
                 <p class="pt-2">
-                  <small><strong><%= current_user.username %> <%= " ~ " %></strong></small>
+                  <small><strong><%= room_message.user.username %> <%= " ~ " %></strong></small>
                   <%= room_message.message %>
                 </p>
                 <div class="text-right mb-2 mr-2">
@@ -80,4 +81,5 @@
       </div>
     </div>
   </div>
+</div>
 </div>


### PR DESCRIPTION
What: Fixed username/avatar in chat
Why: In order to have each avatar/username match each person's actual message
How: changed "current_user" to "room_message_user"