### PR TITLE
Added text wrap for long titles on club index cards

### DIFF
--- a/app/views/clubs/index.html.erb
+++ b/app/views/clubs/index.html.erb
@@ -66,7 +66,7 @@
               <div class="col-md-6 d-flex align-items-center">
                 <div class="card-body">
 
-                  <h5 class="card-title"><%= club.name %></h5>
+                  <h5 class="card-title text-wrap" style="width: 9rem;"><%= club.name %></h5>
                 </div>
               </div>
             </div>
@@ -101,7 +101,7 @@
               <div class="col-md-6 d-flex align-items-center">
                 <div class="card-body">
 
-                  <h5 class="card-title"><%= club.name %></h5>
+                  <h5 class="card-title text-wrap" style="width: 9rem;"><%= club.name %></h5>
                 </div>
               </div>
             </div>
@@ -136,7 +136,7 @@
               </div>
               <div class="col-md-6 d-flex align-items-center">
                 <div class="card-body">
-                  <h5 class="card-title"><%= club.name %></h5>
+                  <h5 class="card-title text-wrap" style="width: 9rem;"><%= club.name %></h5>
                 </div>
               </div>
             </div>
@@ -173,7 +173,7 @@
               <div class="col-md-6 d-flex align-items-center">
                 <div class="card-body">
 
-                  <h5 class="card-title"><%= club.name %></h5>
+                  <h5 class="card-title text-wrap" style="width: 9rem;"><%= club.name %></h5>
                 </div>
               </div>
             </div>
@@ -210,7 +210,7 @@
               <div class="col-md-6 d-flex align-items-center">
                 <div class="card-body">
 
-                  <h5 class="card-title"><%= club.name %></h5>
+                  <h5 class="card-title text-wrap" style="width: 9rem;"><%= club.name %></h5>
                 </div>
               </div>
             </div>
@@ -247,7 +247,7 @@
               <div class="col-md-6 d-flex align-items-center">
                 <div class="card-body">
 
-                  <h5 class="card-title"><%= club.name %></h5>
+                  <h5 class="card-title text-wrap" style="width: 9rem;"><%= club.name %></h5>
                 </div>
               </div>
             </div>
@@ -284,7 +284,7 @@
               <div class="col-md-6 d-flex align-items-center">
                 <div class="card-body">
 
-                  <h5 class="card-title"><%= club.name %></h5>
+                  <h5 class="card-title text-wrap" style="width: 9rem;"><%= club.name %></h5>
                 </div>
               </div>
             </div>
@@ -321,7 +321,7 @@
               <div class="col-md-6 d-flex align-items-center">
                 <div class="card-body">
 
-                  <h5 class="card-title"><%= club.name %></h5>
+                  <h5 class="card-title text-wrap" style="width: 9rem;"><%= club.name %></h5>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
**Why?**
If a club had a long single-word it might overflow the card. This text-wrap resolves this